### PR TITLE
Fixed issue found in the Npgsql use of the appender.

### DIFF
--- a/src/AdoNetAppender.cs
+++ b/src/AdoNetAppender.cs
@@ -571,8 +571,6 @@ namespace MicroKnights.Logging
 					{
 						dbCmd.Transaction = dbTran;
 					}
-					// prepare the command, which is significantly faster
-					dbCmd.Prepare();
 					// run for all events
 					foreach (LoggingEvent e in events)
 					{
@@ -589,6 +587,8 @@ namespace MicroKnights.Logging
 						// Execute the query
 						dbCmd.ExecuteNonQuery();
 					}
+					// prepare the command, which is significantly faster
+					dbCmd.Prepare();
 				}
 			}
 			else


### PR DESCRIPTION
This is the issue found on the various sources
stackoverflow  https://stackoverflow.com/questions/56270330/log4net-adonetappender-npgsql-throws-42601-syntax-error-at-or-near
issues.apache.org  https://issues.apache.org/jira/browse/LOG4NET-538

I did test that this works with postgresql, but I have not tried it with any other database.